### PR TITLE
Nd remove ratings

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -95,3 +95,13 @@ export const logInUser = (data) => {
     this.setState({ wrongInput: '', error: 'Something went wrong on our end' });
   })
 }
+
+export const deleteMovieRating = (id, ratingID) => {
+  return fetch(`https://rancid-tomatillos.herokuapp.com/api/v2/users/${id}/ratings/${ratingID}`, {
+    method: 'DELETE'
+  })
+  .catch(error => {
+    console.log(error);
+    return { wrongInput: '', error: 'We were not able to delete your rating. Please refresh and try again.'}
+  })
+}

--- a/src/components/MovieMain/MovieMain.js
+++ b/src/components/MovieMain/MovieMain.js
@@ -20,10 +20,8 @@ class MovieMain extends Component {
   }
 
   getAllMovieData = () => {
-    console.log('made it here')
     getAllMovies().then(response => {
       this.setState(response)
-      console.log(this.state)
     })
   }
 

--- a/src/components/MovieShowPage/MovieShowPage.js
+++ b/src/components/MovieShowPage/MovieShowPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import {getOneMovie, rateMovie} from '../../apiCalls.js'
+import { getOneMovie, rateMovie, deleteMovieRating } from '../../apiCalls.js'
 
 class MovieShowPage extends Component {
   constructor(props) {
@@ -36,12 +36,28 @@ class MovieShowPage extends Component {
     this.setState({ [name]: value})
   }
 
+  deleteRating = () => {
+    const foundRating = this.props.userMovieRatings.find(movie => movie.movie_id === this.state.movie.id);
+    if (foundRating) {
+      deleteMovieRating(this.props.userID, foundRating.id).then(() => {
+        this.props.populateUserRatings()
+      });
+
+    } else {
+      this.setState({error : 'We were not able to delete your rating.'});
+    }
+  }
+
   render() {
     const foundRating = this.props.userMovieRatings.find(rating => rating.movie_id === this.state.movie.id)
     let userRatingSection = '';
 
     if (foundRating) {
-      userRatingSection = <h3 className='movie-user-rating'>Your Rating: {foundRating.rating}</h3>
+      userRatingSection = 
+      <section>
+        <h3 className='movie-user-rating'>Your Rating: {foundRating.rating}</h3>
+        <button className='delete-user-rating' onClick={this.deleteRating}>Delete Rating</button>
+      </section>
     } else {
       userRatingSection =
       <label htmlFor='rating'>Rate this movie:

--- a/src/components/Navbar/NavBar.test.js
+++ b/src/components/Navbar/NavBar.test.js
@@ -12,14 +12,21 @@ describe("NavBar", () => {
 
   it('Should display on the App', () => {
     const mockFunction = jest.fn();
-    render(<MemoryRouter><NavBar currentUser={"Lucy"} signOut={mockFunction} /></MemoryRouter>)
+    render(<MemoryRouter><NavBar currentUser={"Lucy"} signOut={mockFunction} /></MemoryRouter>);
     expect(screen.getByText('Lucy')).toBeInTheDocument();
     expect(screen.getByText('Rancid Tomatillos')).toBeInTheDocument();
-  })
+  });
+
+  it("Should display a user name if a user is logged in", () => {
+    const mockFunction = jest.fn();
+    render(<MemoryRouter><NavBar currentUser={"Lucy"} signOut={mockFunction} /></MemoryRouter>);
+    expect(screen.getByText('Lucy')).toBeInTheDocument();
+    expect(screen.getByText('Rancid Tomatillos')).toBeInTheDocument();
+  });
 
   it("Should not display a user name if no user is logged in", () => {
     const mockFunction = jest.fn();
-    render(<MemoryRouter><NavBar currentUser={""} signOut={mockFunction} /></MemoryRouter>)
+    render(<MemoryRouter><NavBar currentUser={""} signOut={mockFunction} /></MemoryRouter>);
     expect(screen.getByText('Rancid Tomatillos')).toBeInTheDocument();
-  })
+  });
 })

--- a/src/components/Sign-In/Sign-In.js
+++ b/src/components/Sign-In/Sign-In.js
@@ -34,9 +34,9 @@ class SignIn extends Component {
     return (
       <form>
         <label htmlFor='email'>Email</label>
-        <input name='email' type='text' onChange={this.updateState}/>
+        <input name='email' type='text' placeholder='email' onChange={this.updateState}/>
         <label htmlFor='password'>Password</label>
-        <input name='password' type='password' onChange={this.updateState}/>
+        <input name='password' type='password' placeholder='password' onChange={this.updateState}/>
         <button onClick={this.evaluateUser}>Submit</button>
         { (this.state.wrongInput || this.state.error) ? <h3>{this.state.wrongInput || this.state.error }</h3> : ''}
       </form>

--- a/src/components/Sign-In/Sign-In.test.js
+++ b/src/components/Sign-In/Sign-In.test.js
@@ -1,9 +1,13 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom';
 
 import SignIn from './Sign-In';
+
+import { logInUser } from '../../apiCalls'
+
+jest.mock('../../apiCalls.js')
 
 describe('Sign-In', () => {
   it("Should render the component", () => {
@@ -14,26 +18,26 @@ describe('Sign-In', () => {
     expect(screen.getByText('Submit')).toBeInTheDocument();
   });
 
-  // This test will work, however it won't work until async testing is introduced.
-  // it("Should log in a user on submit button click with correct credientals", () => {
-  //   const mockSignIn = jest.fn();
-  //   global.alert = jest.fn();
-  //   render(<SignIn logIn={mockSignIn} />)
-  //   userEvent.click(screen.getByText('Submit'));
-  //   expect(screen.getByText('Submit')).toBeInTheDocument();
-  //   expect(mockSignIn).toHaveBeenCalledWith(1);
-  // });
+  it("Should log in a user on submit button click with correct credientals", async () => {
+    const userData = {
+      email: 'lucy@turing.io',
+      password: 'passwor1'
+    }
+    logInUser.mockResolvedValue(userData)
+    const mockSignIn = jest.fn();
+    render(<SignIn logIn={mockSignIn} />)
+    userEvent.type(screen.getByPlaceholderText('email'), userData.email);
+    userEvent.type(screen.getByPlaceholderText('password'), userData.password);
+    userEvent.click(screen.getByText('Submit'));
+    screen.debug();
+    // expect(mockSignIn).toHaveBeenCalled();
+  });
 
-  // Unsure about this one, but I'd imagine it would work with async testing as well
-  // it("Should handle wrong username and password errors", () => {
-    // const mockSignIn = jest.fn();
-    // global.alert = jest.fn();
-    // const mockSignInInfo = {
-    //   email: 'turing@turing.io',
-    //   password: '123456'
-    // }
-    // render(<SignIn logIn={mockSignIn} />);
-    // userEvent.click(screen.getByText('Submit'));
-    // expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong on our end');
-  // });
+  it("Should handle wrong username and password errors", () => {
+    const mockSignIn = jest.fn();
+    render(<SignIn logIn={mockSignIn} />);
+    userEvent.click(screen.getByText('Submit'));
+    const message = screen.getByText('Wrong email or password');
+    expect(message).toBeInTheDocument();
+  });
 })


### PR DESCRIPTION
#### What’s this PR do?

- A user will be able to delete a rating that they have already submitted.
- After deleting their rating, they are able to input a new rating for that movie right away.
- A user can only leave one rating per movie.
- Expands on component unit testing and some integrating testing.

#### Where should the reviewer start?

- Git pull this branch.

#### How should this be manually tested?

- run `npm install` as we had to install js-dom-sixteen in order to get our test suite working.
- run `npm test` to see the testing results.
- run `npm start` and navigate to localhost:3000.
- login with the user lucy `email: lucy@turing.io, password: password1`.
- Navigate to a page that Lucy has submitted a rating with.
- Click the delete rating button.
- Ensure the rating goes away and the form to submit a new rating repopulates.
- Add a new rating to ensure that the form disappears and shows their rating with the delete button.

#### Any background context you want to provide?

- Had to install js-dom-sixteen in order to get past mutation error when using `waitFor`. Run `npm install` to update local files.

#### What are the relevant tickets?

- closes #34 

#### Screenshots (if appropriate):
- N/A

#### Questions:
- N/A